### PR TITLE
Added labels and capabilities deletion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,46 @@ Use the `registryCredentials` subcommand to create registry credentials for curr
 
 The `delete` command deletes the given resource.
 
+#### Deleting labels
+
+##### Deleting account labels
+
+Use the `accountLabel` subcommand to delete a label from an account, passing the label key. 
+
+##### Deleting organization labels
+
+Use the `organizationLabel` subcommand to delete a label from an organization, passing the label key. 
+
+##### Deleting subscription labels
+
+Use the `subscriptionLabel` subcommand to delete a label from a subscription, passing the label key. 
+
+##### Examples
+
+* Delete a label from an account `ocm support delete accountLabel [accountID] [key]`
+* Delete a label from an organization `ocm support delete organizationLabel [orgID] [key]`
+* Delete a label from a subscription `ocm support delete subscriptionLabel [subscriptionID] [key]`
+
+#### Deleting capabilities
+
+##### Deleting account capabilities
+
+Use the `accountCapability` subcommand to delete a capability from an account, passing the valid capability key. 
+
+##### Deleting organization capabilities
+
+Use the `organizationCapability` subcommand to delete a capability from an organization, passing the valid capability key. 
+
+##### Deleting subscription capabilities
+
+Use the `subscriptionCapability` subcommand to delete a capability from a subscription, passing a valid capability key. 
+
+##### Examples
+
+* Delete a capability from an account `ocm support delete accountCapability [accountID] [capabilityKey]`
+* Delete a capability from an organization `ocm support delete organizationCapability [orgID] [capabilityKey]`
+* Delete a capability from a subscription `ocm support delete subscriptionCapability [subscriptionID] [capabilityKey]`
+
 #### Deleting registry credentials
 
 Use the `registryCredentials` subcommand to to delete a specific registry credential, or all registry credentials, for the passed accountID.

--- a/cmd/ocm-support/create/capabilities/account_capability/cmd.go
+++ b/cmd/ocm-support/create/capabilities/account_capability/cmd.go
@@ -43,12 +43,12 @@ var CmdCreateAccountCapability = &cobra.Command{
 
 func runCreateAccountCapability(cmd *cobra.Command, argv []string) error {
 	accountID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	capabilityKey, err := capability.GetCapability(key, "account")
 	if err != nil {
 		return fmt.Errorf("failed to get capability: %v", err)

--- a/cmd/ocm-support/create/capabilities/organization_capability/cmd.go
+++ b/cmd/ocm-support/create/capabilities/organization_capability/cmd.go
@@ -43,12 +43,12 @@ var CmdCreateOrganizationCapability = &cobra.Command{
 
 func runCreateOrganizationCapability(cmd *cobra.Command, argv []string) error {
 	organizationID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	capabilityKey, err := capability.GetCapability(key, "organization")
 	if err != nil {
 		return fmt.Errorf("failed to get capability: %v", err)

--- a/cmd/ocm-support/create/capabilities/subscription_capability/cmd.go
+++ b/cmd/ocm-support/create/capabilities/subscription_capability/cmd.go
@@ -43,12 +43,12 @@ var CmdCreateSubscriptionCapability = &cobra.Command{
 
 func runCreateSubscriptionCapability(cmd *cobra.Command, argv []string) error {
 	subscriptionID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	capabilityKey, err := capability.GetCapability(key, "cluster")
 	if err != nil {
 		return fmt.Errorf("failed to get capability: %v", err)

--- a/cmd/ocm-support/create/labels/account_label/cmd.go
+++ b/cmd/ocm-support/create/labels/account_label/cmd.go
@@ -50,13 +50,13 @@ func init() {
 
 func runCreateAccountLabel(cmd *cobra.Command, argv []string) error {
 	accountID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	value := argv[2]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
-	value := argv[2]
 	createdLabel, err := account.AddLabel(accountID, key, value, !args.external, connection)
 	if err != nil {
 		return fmt.Errorf("failed to create label: %v", err)

--- a/cmd/ocm-support/create/labels/organization_label/cmd.go
+++ b/cmd/ocm-support/create/labels/organization_label/cmd.go
@@ -50,13 +50,13 @@ func init() {
 
 func runCreateOrganizationLabel(cmd *cobra.Command, argv []string) error {
 	organizationID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	value := argv[2]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
-	value := argv[2]
 	createdLabel, err := organization.AddLabel(organizationID, key, value, !args.external, connection)
 	if err != nil {
 		return fmt.Errorf("failed to create label: %v", err)

--- a/cmd/ocm-support/create/labels/subscription_label/cmd.go
+++ b/cmd/ocm-support/create/labels/subscription_label/cmd.go
@@ -50,13 +50,13 @@ func init() {
 
 func runCreateSubscriptionLabel(cmd *cobra.Command, argv []string) error {
 	subscriptionID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	value := argv[2]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
-	value := argv[2]
 	createdLabel, err := subscription.AddLabel(subscriptionID, key, value, !args.external, connection)
 	if err != nil {
 		return fmt.Errorf("failed to create label: %v", err)

--- a/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
@@ -1,0 +1,59 @@
+package account
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-support-cli/pkg/account"
+	"github.com/openshift-online/ocm-support-cli/pkg/capability"
+)
+
+// CmdDeleteAccountCapability represents the delete account capability command
+var CmdDeleteAccountCapability = &cobra.Command{
+	Use:   "accountCapability [accountID] [capability]",
+	Short: "Removed a Capability to an Account",
+	Long:  "Removed a Capability to an Account",
+	RunE:  runDeleteAccountCapability,
+	Args:  cobra.ExactArgs(2),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		accountID := args[0]
+		connection, err := ocm.NewConnection().Build()
+		if err != nil {
+			return fmt.Errorf("failed to create OCM connection: %v", err)
+		}
+		// validates the account
+		err = account.ValidateAccount(accountID, connection)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		//validates the capability
+		capabilityKey := args[1]
+		err = capability.ValidateCapability(capabilityKey, "account")
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return nil
+	},
+}
+
+func runDeleteAccountCapability(cmd *cobra.Command, argv []string) error {
+	accountID := argv[0]
+	// TODO : avoid creating multiple connection pools
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	key := argv[1]
+	capabilityKey, err := capability.GetCapability(key, "account")
+	if err != nil {
+		return fmt.Errorf("failed to get capability: %v", err)
+	}
+	err = account.DeleteLabel(accountID, capabilityKey, connection)
+	if err != nil {
+		return fmt.Errorf("failed to delete capability: %v", err)
+	}
+	fmt.Printf("capability '%s' deleted successfully\n", key)
+	return nil
+}

--- a/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
@@ -19,6 +19,7 @@ var CmdDeleteAccountCapability = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		accountID := args[0]
+		capabilityKey := args[1]
 		connection, err := ocm.NewConnection().Build()
 		if err != nil {
 			return fmt.Errorf("failed to create OCM connection: %v", err)
@@ -29,7 +30,6 @@ var CmdDeleteAccountCapability = &cobra.Command{
 			return fmt.Errorf("%v", err)
 		}
 		//validates the capability
-		capabilityKey := args[1]
 		err = capability.ValidateCapability(capabilityKey, "account")
 		if err != nil {
 			return fmt.Errorf("%v", err)

--- a/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
@@ -13,8 +13,8 @@ import (
 // CmdDeleteAccountCapability represents the delete account capability command
 var CmdDeleteAccountCapability = &cobra.Command{
 	Use:   "accountCapability [accountID] [capability]",
-	Short: "Removes a Capability to an Account",
-	Long:  "Removes a Capability to an Account",
+	Short: "Removes a Capability from an Account",
+	Long:  "Removes a Capability from an Account",
 	RunE:  runDeleteAccountCapability,
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -54,6 +54,6 @@ func runDeleteAccountCapability(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete capability: %v", err)
 	}
-	fmt.Printf("capability '%s' successfully from account %s\n", key, accountID)
+	fmt.Printf("capability '%s' successfully removed from account %s\n", key, accountID)
 	return nil
 }

--- a/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/account_capability/cmd.go
@@ -13,8 +13,8 @@ import (
 // CmdDeleteAccountCapability represents the delete account capability command
 var CmdDeleteAccountCapability = &cobra.Command{
 	Use:   "accountCapability [accountID] [capability]",
-	Short: "Removed a Capability to an Account",
-	Long:  "Removed a Capability to an Account",
+	Short: "Removes a Capability to an Account",
+	Long:  "Removes a Capability to an Account",
 	RunE:  runDeleteAccountCapability,
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -40,12 +40,12 @@ var CmdDeleteAccountCapability = &cobra.Command{
 
 func runDeleteAccountCapability(cmd *cobra.Command, argv []string) error {
 	accountID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	capabilityKey, err := capability.GetCapability(key, "account")
 	if err != nil {
 		return fmt.Errorf("failed to get capability: %v", err)
@@ -54,6 +54,6 @@ func runDeleteAccountCapability(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete capability: %v", err)
 	}
-	fmt.Printf("capability '%s' deleted successfully\n", key)
+	fmt.Printf("capability '%s' successfully from account %s\n", key, accountID)
 	return nil
 }

--- a/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
@@ -23,7 +23,7 @@ var CmdDeleteOrganizationCapability = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create OCM connection: %v", err)
 		}
-		// validates the account
+		// validates the organization
 		err = organization.ValidateOrganization(orgID, connection)
 		if err != nil {
 			return fmt.Errorf("%v", err)
@@ -40,12 +40,12 @@ var CmdDeleteOrganizationCapability = &cobra.Command{
 
 func runDeleteOrganizationCapability(cmd *cobra.Command, argv []string) error {
 	orgID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	capabilityKey, err := capability.GetCapability(key, "organization")
 	if err != nil {
 		return fmt.Errorf("failed to get capability: %v", err)
@@ -54,6 +54,6 @@ func runDeleteOrganizationCapability(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete capability: %v", err)
 	}
-	fmt.Printf("capability '%s' deleted successfully\n", key)
+	fmt.Printf("capability '%s' successfully from organization %s\n", key, orgID)
 	return nil
 }

--- a/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
@@ -13,8 +13,8 @@ import (
 // CmdDeleteOrganizationCapability represents the delete organization capability command
 var CmdDeleteOrganizationCapability = &cobra.Command{
 	Use:   "organizationCapability [orgID] [capability]",
-	Short: "Removes a Capability to an organization",
-	Long:  "Removes a Capability to an organization",
+	Short: "Removes a Capability from an organization",
+	Long:  "Removes a Capability from an organization",
 	RunE:  runDeleteOrganizationCapability,
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -54,6 +54,6 @@ func runDeleteOrganizationCapability(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete capability: %v", err)
 	}
-	fmt.Printf("capability '%s' successfully from organization %s\n", key, orgID)
+	fmt.Printf("capability '%s' successfully removed from organization %s\n", key, orgID)
 	return nil
 }

--- a/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
@@ -19,6 +19,7 @@ var CmdDeleteOrganizationCapability = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		orgID := args[0]
+		capabilityKey := args[1]
 		connection, err := ocm.NewConnection().Build()
 		if err != nil {
 			return fmt.Errorf("failed to create OCM connection: %v", err)
@@ -29,7 +30,6 @@ var CmdDeleteOrganizationCapability = &cobra.Command{
 			return fmt.Errorf("%v", err)
 		}
 		//validates the capability
-		capabilityKey := args[1]
 		err = capability.ValidateCapability(capabilityKey, "organization")
 		if err != nil {
 			return fmt.Errorf("%v", err)

--- a/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/organization_capability/cmd.go
@@ -1,0 +1,59 @@
+package organization
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-support-cli/pkg/capability"
+	"github.com/openshift-online/ocm-support-cli/pkg/organization"
+)
+
+// CmdDeleteOrganizationCapability represents the delete organization capability command
+var CmdDeleteOrganizationCapability = &cobra.Command{
+	Use:   "organizationCapability [orgID] [capability]",
+	Short: "Removes a Capability to an organization",
+	Long:  "Removes a Capability to an organization",
+	RunE:  runDeleteOrganizationCapability,
+	Args:  cobra.ExactArgs(2),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		orgID := args[0]
+		connection, err := ocm.NewConnection().Build()
+		if err != nil {
+			return fmt.Errorf("failed to create OCM connection: %v", err)
+		}
+		// validates the account
+		err = organization.ValidateOrganization(orgID, connection)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		//validates the capability
+		capabilityKey := args[1]
+		err = capability.ValidateCapability(capabilityKey, "organization")
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return nil
+	},
+}
+
+func runDeleteOrganizationCapability(cmd *cobra.Command, argv []string) error {
+	orgID := argv[0]
+	// TODO : avoid creating multiple connection pools
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	key := argv[1]
+	capabilityKey, err := capability.GetCapability(key, "organization")
+	if err != nil {
+		return fmt.Errorf("failed to get capability: %v", err)
+	}
+	err = organization.DeleteLabel(orgID, capabilityKey, connection)
+	if err != nil {
+		return fmt.Errorf("failed to delete capability: %v", err)
+	}
+	fmt.Printf("capability '%s' deleted successfully\n", key)
+	return nil
+}

--- a/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift-online/ocm-support-cli/pkg/subscription"
 )
 
-// CmdDeleteSubscriptionCapability represents the create account capability command
+// CmdDeleteSubscriptionCapability represents the delete subscription capability command
 var CmdDeleteSubscriptionCapability = &cobra.Command{
 	Use:   "subscriptionCapability [subscriptionID] [capability]",
 	Short: "Removes a Capability to a Subscription",
@@ -23,7 +23,7 @@ var CmdDeleteSubscriptionCapability = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create OCM connection: %v", err)
 		}
-		// validates the account
+		// validates the subscription
 		err = subscription.ValidateSubscription(subscriptionID, connection)
 		if err != nil {
 			return fmt.Errorf("%v", err)
@@ -40,12 +40,12 @@ var CmdDeleteSubscriptionCapability = &cobra.Command{
 
 func runDeleteSubscriptionCapability(cmd *cobra.Command, argv []string) error {
 	subscriptionID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	capabilityKey, err := capability.GetCapability(key, "cluster")
 	if err != nil {
 		return fmt.Errorf("failed to get capability: %v", err)
@@ -54,6 +54,6 @@ func runDeleteSubscriptionCapability(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete capability: %v", err)
 	}
-	fmt.Printf("capability '%s' deleted successfully\n", key)
+	fmt.Printf("capability '%s' successfully from account %s\n", key, subscriptionID)
 	return nil
 }

--- a/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
@@ -19,6 +19,7 @@ var CmdDeleteSubscriptionCapability = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		subscriptionID := args[0]
+		capabilityKey := args[1]
 		connection, err := ocm.NewConnection().Build()
 		if err != nil {
 			return fmt.Errorf("failed to create OCM connection: %v", err)
@@ -29,7 +30,6 @@ var CmdDeleteSubscriptionCapability = &cobra.Command{
 			return fmt.Errorf("%v", err)
 		}
 		//validates the capability
-		capabilityKey := args[1]
 		err = capability.ValidateCapability(capabilityKey, "cluster")
 		if err != nil {
 			return fmt.Errorf("%v", err)

--- a/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
@@ -13,8 +13,8 @@ import (
 // CmdDeleteSubscriptionCapability represents the delete subscription capability command
 var CmdDeleteSubscriptionCapability = &cobra.Command{
 	Use:   "subscriptionCapability [subscriptionID] [capability]",
-	Short: "Removes a Capability to a Subscription",
-	Long:  "Removes a Capability to a Subscription",
+	Short: "Removes a Capability from a Subscription",
+	Long:  "Removes a Capability from a Subscription",
 	RunE:  runDeleteSubscriptionCapability,
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -54,6 +54,6 @@ func runDeleteSubscriptionCapability(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete capability: %v", err)
 	}
-	fmt.Printf("capability '%s' successfully from account %s\n", key, subscriptionID)
+	fmt.Printf("capability '%s' successfully removed from account %s\n", key, subscriptionID)
 	return nil
 }

--- a/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
+++ b/cmd/ocm-support/delete/capabilities/subscription_capability/cmd.go
@@ -1,0 +1,59 @@
+package subscription
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-support-cli/pkg/capability"
+	"github.com/openshift-online/ocm-support-cli/pkg/subscription"
+)
+
+// CmdDeleteSubscriptionCapability represents the create account capability command
+var CmdDeleteSubscriptionCapability = &cobra.Command{
+	Use:   "subscriptionCapability [subscriptionID] [capability]",
+	Short: "Removes a Capability to a Subscription",
+	Long:  "Removes a Capability to a Subscription",
+	RunE:  runDeleteSubscriptionCapability,
+	Args:  cobra.ExactArgs(2),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		subscriptionID := args[0]
+		connection, err := ocm.NewConnection().Build()
+		if err != nil {
+			return fmt.Errorf("failed to create OCM connection: %v", err)
+		}
+		// validates the account
+		err = subscription.ValidateSubscription(subscriptionID, connection)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		//validates the capability
+		capabilityKey := args[1]
+		err = capability.ValidateCapability(capabilityKey, "cluster")
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return nil
+	},
+}
+
+func runDeleteSubscriptionCapability(cmd *cobra.Command, argv []string) error {
+	subscriptionID := argv[0]
+	// TODO : avoid creating multiple connection pools
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	key := argv[1]
+	capabilityKey, err := capability.GetCapability(key, "cluster")
+	if err != nil {
+		return fmt.Errorf("failed to get capability: %v", err)
+	}
+	err = subscription.DeleteLabel(subscriptionID, capabilityKey, connection)
+	if err != nil {
+		return fmt.Errorf("failed to delete capability: %v", err)
+	}
+	fmt.Printf("capability '%s' deleted successfully\n", key)
+	return nil
+}

--- a/cmd/ocm-support/delete/cmd.go
+++ b/cmd/ocm-support/delete/cmd.go
@@ -15,8 +15,8 @@ import (
 // Cmd ...
 var Cmd = &cobra.Command{
 	Use:   "delete [COMMAND]",
-	Short: "Removes Labels, Capabilities to Accounts, Subscriptions, Organizations",
-	Long:  "Removes Labels, Capabilities to Accounts, Subscriptions, Organizations",
+	Short: "Removes Labels, Capabilities from Accounts, Subscriptions, Organizations",
+	Long:  "Removes Labels, Capabilities from Accounts, Subscriptions, Organizations",
 	Args:  cobra.MinimumNArgs(1),
 }
 

--- a/cmd/ocm-support/delete/cmd.go
+++ b/cmd/ocm-support/delete/cmd.go
@@ -3,17 +3,29 @@ package delete
 import (
 	"github.com/spf13/cobra"
 
-	registrycredentials "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/registry_credentials"
+	accountCapability "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/capabilities/account_capability"
+	organizationCapability "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/capabilities/organization_capability"
+	subscriptionCapability "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/capabilities/subscription_capability"
+	accountLabel "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/labels/account_label"
+	organizationLabel "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/labels/organization_label"
+	subscriptionLabel "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/labels/subscription_label"
+	registryCredentials "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/registry_credentials"
 )
 
 // Cmd ...
 var Cmd = &cobra.Command{
 	Use:   "delete [COMMAND]",
-	Short: "Deletes the given resource",
-	Long:  "Deletes the given resource",
+	Short: "Removes Labels, Capabilities to Accounts, Subscriptions, Organizations",
+	Long:  "Removes Labels, Capabilities to Accounts, Subscriptions, Organizations",
 	Args:  cobra.MinimumNArgs(1),
 }
 
 func init() {
-	Cmd.AddCommand(registrycredentials.CmdDeleteRegistryCredentials)
+	Cmd.AddCommand(registryCredentials.CmdDeleteRegistryCredentials)
+	Cmd.AddCommand(accountCapability.CmdDeleteAccountCapability)
+	Cmd.AddCommand(organizationCapability.CmdDeleteOrganizationCapability)
+	Cmd.AddCommand(subscriptionCapability.CmdDeleteSubscriptionCapability)
+	Cmd.AddCommand(accountLabel.CmdDeleteAccountLabel)
+	Cmd.AddCommand(organizationLabel.CmdDeleteOrganizationLabel)
+	Cmd.AddCommand(subscriptionLabel.CmdDeleteSubscriptionLabel)
 }

--- a/cmd/ocm-support/delete/labels/account_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/account_label/cmd.go
@@ -12,8 +12,8 @@ import (
 // CmdDeleteAccountLabel represents the delete account label command
 var CmdDeleteAccountLabel = &cobra.Command{
 	Use:   "accountLabel [accountID] [key]",
-	Short: "Removes a Label to an Account",
-	Long:  "Removes a Label to an Account",
+	Short: "Removes a Label from an Account",
+	Long:  "Removes a Label from an Account",
 	RunE:  runDeleteAccountLabel,
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -43,6 +43,6 @@ func runDeleteAccountLabel(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete label: %v", err)
 	}
-	fmt.Printf("label '%s' successfully from account %s\n", key, accountID)
+	fmt.Printf("label '%s' successfully removed from account %s\n", key, accountID)
 	return nil
 }

--- a/cmd/ocm-support/delete/labels/account_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/account_label/cmd.go
@@ -33,16 +33,16 @@ var CmdDeleteAccountLabel = &cobra.Command{
 
 func runDeleteAccountLabel(cmd *cobra.Command, argv []string) error {
 	accountID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	err = account.DeleteLabel(accountID, key, connection)
 	if err != nil {
 		return fmt.Errorf("failed to delete label: %v", err)
 	}
-	fmt.Printf("label '%s' deleted successfully\n", key)
+	fmt.Printf("label '%s' successfully from account %s\n", key, accountID)
 	return nil
 }

--- a/cmd/ocm-support/delete/labels/account_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/account_label/cmd.go
@@ -1,0 +1,48 @@
+package account
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-support-cli/pkg/account"
+)
+
+// CmdDeleteAccountLabel represents the delete account label command
+var CmdDeleteAccountLabel = &cobra.Command{
+	Use:   "accountLabel [accountID] [key]",
+	Short: "Removes a Label to an Account",
+	Long:  "Removes a Label to an Account",
+	RunE:  runDeleteAccountLabel,
+	Args:  cobra.ExactArgs(2),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		accountID := args[0]
+		connection, err := ocm.NewConnection().Build()
+		if err != nil {
+			return fmt.Errorf("failed to create OCM connection: %v", err)
+		}
+		// validates the account
+		err = account.ValidateAccount(accountID, connection)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return nil
+	},
+}
+
+func runDeleteAccountLabel(cmd *cobra.Command, argv []string) error {
+	accountID := argv[0]
+	// TODO : avoid creating multiple connection pools
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	key := argv[1]
+	err = account.DeleteLabel(accountID, key, connection)
+	if err != nil {
+		return fmt.Errorf("failed to delete label: %v", err)
+	}
+	fmt.Printf("label '%s' deleted successfully\n", key)
+	return nil
+}

--- a/cmd/ocm-support/delete/labels/organization_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/organization_label/cmd.go
@@ -22,7 +22,7 @@ var CmdDeleteOrganizationLabel = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create OCM connection: %v", err)
 		}
-		// validates the account
+		// validates the organization
 		err = organization.ValidateOrganization(orgID, connection)
 		if err != nil {
 			return fmt.Errorf("%v", err)
@@ -33,16 +33,16 @@ var CmdDeleteOrganizationLabel = &cobra.Command{
 
 func runDeleteOrganizationLabel(cmd *cobra.Command, argv []string) error {
 	orgID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	err = organization.DeleteLabel(orgID, key, connection)
 	if err != nil {
 		return fmt.Errorf("failed to delete label: %v", err)
 	}
-	fmt.Printf("label '%s' deleted successfully\n", key)
+	fmt.Printf("label '%s' successfully from organization %s\n", key, orgID)
 	return nil
 }

--- a/cmd/ocm-support/delete/labels/organization_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/organization_label/cmd.go
@@ -1,0 +1,48 @@
+package organization
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-support-cli/pkg/organization"
+)
+
+// CmdDeleteOrganizationLabel represents the delete organization label command
+var CmdDeleteOrganizationLabel = &cobra.Command{
+	Use:   "organizationLabel [orgID] [key]",
+	Short: "Removes a Label to an organization",
+	Long:  "Removes a Label to an organization",
+	RunE:  runDeleteOrganizationLabel,
+	Args:  cobra.ExactArgs(2),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		orgID := args[0]
+		connection, err := ocm.NewConnection().Build()
+		if err != nil {
+			return fmt.Errorf("failed to create OCM connection: %v", err)
+		}
+		// validates the account
+		err = organization.ValidateOrganization(orgID, connection)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return nil
+	},
+}
+
+func runDeleteOrganizationLabel(cmd *cobra.Command, argv []string) error {
+	orgID := argv[0]
+	// TODO : avoid creating multiple connection pools
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	key := argv[1]
+	err = organization.DeleteLabel(orgID, key, connection)
+	if err != nil {
+		return fmt.Errorf("failed to delete label: %v", err)
+	}
+	fmt.Printf("label '%s' deleted successfully\n", key)
+	return nil
+}

--- a/cmd/ocm-support/delete/labels/organization_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/organization_label/cmd.go
@@ -12,8 +12,8 @@ import (
 // CmdDeleteOrganizationLabel represents the delete organization label command
 var CmdDeleteOrganizationLabel = &cobra.Command{
 	Use:   "organizationLabel [orgID] [key]",
-	Short: "Removes a Label to an organization",
-	Long:  "Removes a Label to an organization",
+	Short: "Removes a Label from an organization",
+	Long:  "Removes a Label from an organization",
 	RunE:  runDeleteOrganizationLabel,
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -43,6 +43,6 @@ func runDeleteOrganizationLabel(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete label: %v", err)
 	}
-	fmt.Printf("label '%s' successfully from organization %s\n", key, orgID)
+	fmt.Printf("label '%s' successfully removed from organization %s\n", key, orgID)
 	return nil
 }

--- a/cmd/ocm-support/delete/labels/subscription_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/subscription_label/cmd.go
@@ -1,0 +1,48 @@
+package subscription
+
+import (
+	"fmt"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-support-cli/pkg/subscription"
+)
+
+// CmdDeleteSubscriptionLabel represents the create account label command
+var CmdDeleteSubscriptionLabel = &cobra.Command{
+	Use:   "subscriptionLabel [subscriptionID] [key]",
+	Short: "Removes a Label to a Subscription",
+	Long:  "Removes a Label to a Subscription",
+	RunE:  runDeleteSubscriptionLabel,
+	Args:  cobra.ExactArgs(2),
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		subscriptionID := args[0]
+		connection, err := ocm.NewConnection().Build()
+		if err != nil {
+			return fmt.Errorf("failed to create OCM connection: %v", err)
+		}
+		// validates the account
+		err = subscription.ValidateSubscription(subscriptionID, connection)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+		return nil
+	},
+}
+
+func runDeleteSubscriptionLabel(cmd *cobra.Command, argv []string) error {
+	subscriptionID := argv[0]
+	// TODO : avoid creating multiple connection pools
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	key := argv[1]
+	err = subscription.DeleteLabel(subscriptionID, key, connection)
+	if err != nil {
+		return fmt.Errorf("failed to delete label: %v", err)
+	}
+	fmt.Printf("label '%s' deleted successfully\n", key)
+	return nil
+}

--- a/cmd/ocm-support/delete/labels/subscription_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/subscription_label/cmd.go
@@ -12,8 +12,8 @@ import (
 // CmdDeleteSubscriptionLabel represents the create account label command
 var CmdDeleteSubscriptionLabel = &cobra.Command{
 	Use:   "subscriptionLabel [subscriptionID] [key]",
-	Short: "Removes a Label to a Subscription",
-	Long:  "Removes a Label to a Subscription",
+	Short: "Removes a Label from a Subscription",
+	Long:  "Removes a Label from a Subscription",
 	RunE:  runDeleteSubscriptionLabel,
 	Args:  cobra.ExactArgs(2),
 	PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -43,6 +43,6 @@ func runDeleteSubscriptionLabel(cmd *cobra.Command, argv []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete label: %v", err)
 	}
-	fmt.Printf("label '%s' successfully from subscription %s\n", key, subscriptionID)
+	fmt.Printf("label '%s' successfully removed from subscription %s\n", key, subscriptionID)
 	return nil
 }

--- a/cmd/ocm-support/delete/labels/subscription_label/cmd.go
+++ b/cmd/ocm-support/delete/labels/subscription_label/cmd.go
@@ -22,7 +22,7 @@ var CmdDeleteSubscriptionLabel = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("failed to create OCM connection: %v", err)
 		}
-		// validates the account
+		// validates the subscription
 		err = subscription.ValidateSubscription(subscriptionID, connection)
 		if err != nil {
 			return fmt.Errorf("%v", err)
@@ -33,16 +33,16 @@ var CmdDeleteSubscriptionLabel = &cobra.Command{
 
 func runDeleteSubscriptionLabel(cmd *cobra.Command, argv []string) error {
 	subscriptionID := argv[0]
-	// TODO : avoid creating multiple connection pools
+	key := argv[1]
+	// TODO : avoid creating multiple connections by using a connection pool
 	connection, err := ocm.NewConnection().Build()
 	if err != nil {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
-	key := argv[1]
 	err = subscription.DeleteLabel(subscriptionID, key, connection)
 	if err != nil {
 		return fmt.Errorf("failed to delete label: %v", err)
 	}
-	fmt.Printf("label '%s' deleted successfully\n", key)
+	fmt.Printf("label '%s' successfully from subscription %s\n", key, subscriptionID)
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/nwidger/jsoncolor v0.3.1
 	github.com/openshift-online/ocm-cli v0.1.64
-	github.com/openshift-online/ocm-sdk-go v0.1.277
+	github.com/openshift-online/ocm-sdk-go v0.1.281
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -586,8 +586,8 @@ github.com/openshift-online/ocm-cli v0.1.64 h1:U/ILl054dNln9Kb/dhZOCgnhYFwfUMHhj
 github.com/openshift-online/ocm-cli v0.1.64/go.mod h1:Ccu+zHRdPOHNjHVe+MuD54DTk+ZmqcY1F+waulB8ELA=
 github.com/openshift-online/ocm-sdk-go v0.1.219/go.mod h1:uDiBAEupl2F5rkTBFC4y4ZPEV/ku/fFEBHot6OkYL+I=
 github.com/openshift-online/ocm-sdk-go v0.1.273/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
-github.com/openshift-online/ocm-sdk-go v0.1.277 h1:T3224wvmZWfDafKLxdRmHQJjX2Q3vaHM77eDa+7R7QY=
-github.com/openshift-online/ocm-sdk-go v0.1.277/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.281 h1:a1hkVr8Y6l+zedUg+Udt7x/osrGkzUYD4lRN/+8SXhc=
+github.com/openshift-online/ocm-sdk-go v0.1.281/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/rosa v1.1.7/go.mod h1:Ap4vfflxHXfzY0MIt1l9dckwG+DkPUDc/vv1mk1cSCQ=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"context"
 	"fmt"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -65,6 +66,18 @@ func AddLabel(accountID string, key string, value string, isInternal bool, conn 
 		return nil, fmt.Errorf("can't add new label: %w", err)
 	}
 	return lblResponse.Body(), err
+}
+
+func DeleteLabel(accountID string, key string, conn *sdk.Connection) error {
+	ctx := context.Background()
+	labels := conn.AccountsMgmt().V1().Accounts().Account(accountID).Labels()
+
+	resource := labels.Label(key)
+	_, err := resource.Delete().SendContext(ctx)
+	if err != nil {
+		return fmt.Errorf("can't delete label: %w", err)
+	}
+	return nil
 }
 
 func PresentAccount(account *v1.Account, roles []*v1.RoleBinding, registryCredentials []*v1.RegistryCredential) Account {

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -72,8 +72,8 @@ func DeleteLabel(accountID string, key string, conn *sdk.Connection) error {
 	ctx := context.Background()
 	labels := conn.AccountsMgmt().V1().Accounts().Account(accountID).Labels()
 
-	resource := labels.Label(key)
-	_, err := resource.Delete().SendContext(ctx)
+	existingLabel := labels.Label(key)
+	_, err := existingLabel.Delete().SendContext(ctx)
 	if err != nil {
 		return fmt.Errorf("can't delete label: %w", err)
 	}

--- a/pkg/capability/capability.go
+++ b/pkg/capability/capability.go
@@ -64,6 +64,7 @@ var availableCapabilities map[string]string = map[string]string{
 	"OrganizationOverrideOsdTrialLength": CapabilityOrganizationOverrideOsdTrialLength,
 	"OrganizationCreateClusterProxy":     CapabilityOrganizationCreateClusterProxy,
 	"AllowGCPNonCCSPrivateClusters":      CapabilityAllowGCPNonCCSPrivateClusters,
+	"AllowInstallEOLVersions":            CapabilityAllowInstallEOLVersions,
 	"AddOnVersionSelect":                 CapabilityAddOnVersionSelect,
 	"OrganizationFipsCluster":            CapabilityOrganizationFipsCluster,
 	"OrganizationOvnCluster":             CapabilityOrganizationOvnCluster,
@@ -75,12 +76,12 @@ var availableCapabilities map[string]string = map[string]string{
 func PresentCapabilities(capabilities []*v1.Capability) CapabilityList {
 	var capabilitiesList []Capability
 	for _, capability := range capabilities {
-		cap := Capability{
+		formattedCapability := Capability{
 			Name:      capability.Name(),
 			Value:     capability.Value(),
 			Inherited: capability.Inherited(),
 		}
-		capabilitiesList = append(capabilitiesList, cap)
+		capabilitiesList = append(capabilitiesList, formattedCapability)
 	}
 	return capabilitiesList
 }

--- a/pkg/organization/organization.go
+++ b/pkg/organization/organization.go
@@ -61,8 +61,8 @@ func DeleteLabel(orgID string, key string, conn *sdk.Connection) error {
 	ctx := context.Background()
 	labels := conn.AccountsMgmt().V1().Organizations().Organization(orgID).Labels()
 
-	resource := labels.Label(key)
-	_, err := resource.Delete().SendContext(ctx)
+	existingLabel := labels.Label(key)
+	_, err := existingLabel.Delete().SendContext(ctx)
 	if err != nil {
 		return fmt.Errorf("can't delete label: %w", err)
 	}

--- a/pkg/organization/organization.go
+++ b/pkg/organization/organization.go
@@ -1,6 +1,7 @@
 package organization
 
 import (
+	"context"
 	"fmt"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -54,6 +55,18 @@ func AddLabel(orgID string, key string, value string, isInternal bool, conn *sdk
 		return nil, fmt.Errorf("can't add new label: %w", err)
 	}
 	return lblResponse.Body(), err
+}
+
+func DeleteLabel(orgID string, key string, conn *sdk.Connection) error {
+	ctx := context.Background()
+	labels := conn.AccountsMgmt().V1().Organizations().Organization(orgID).Labels()
+
+	resource := labels.Label(key)
+	_, err := resource.Delete().SendContext(ctx)
+	if err != nil {
+		return fmt.Errorf("can't delete label: %w", err)
+	}
+	return nil
 }
 
 func PresentOrganization(organization *v1.Organization, subscriptions []*v1.Subscription, quotaCostList []*v1.QuotaCost) Organization {

--- a/pkg/subscription/subscription.go
+++ b/pkg/subscription/subscription.go
@@ -1,6 +1,7 @@
 package subscription
 
 import (
+	"context"
 	"fmt"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
@@ -52,6 +53,18 @@ func AddLabel(subscriptionID string, key string, value string, isInternal bool, 
 		return nil, fmt.Errorf("can't add new label: %w", err)
 	}
 	return lblResponse.Body(), err
+}
+
+func DeleteLabel(subscriptionID string, key string, conn *sdk.Connection) error {
+	ctx := context.Background()
+	labels := conn.AccountsMgmt().V1().Subscriptions().Subscription(subscriptionID).Labels()
+
+	resource := labels.Label(key)
+	_, err := resource.Delete().SendContext(ctx)
+	if err != nil {
+		return fmt.Errorf("can't delete label: %w", err)
+	}
+	return nil
 }
 
 func PresentSubscriptions(subscriptions []*v1.Subscription) []Subscription {

--- a/pkg/subscription/subscription.go
+++ b/pkg/subscription/subscription.go
@@ -59,8 +59,8 @@ func DeleteLabel(subscriptionID string, key string, conn *sdk.Connection) error 
 	ctx := context.Background()
 	labels := conn.AccountsMgmt().V1().Subscriptions().Subscription(subscriptionID).Labels()
 
-	resource := labels.Label(key)
-	_, err := resource.Delete().SendContext(ctx)
+	existingLabel := labels.Label(key)
+	_, err := existingLabel.Delete().SendContext(ctx)
 	if err != nil {
 		return fmt.Errorf("can't delete label: %w", err)
 	}


### PR DESCRIPTION
**Changed**
- Referred ocm-sdk-go's latest version
- Added methods in account, organization and subscription to delete a label
- Added delete capability and labels command for account, organization and subscription
- Modified readme.md with new delete commands