### PR TITLE
Modified get organizations and accounts commands to allow optional search argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,109 @@ You can use the following command to confirm that the tool was installed correct
 
 To see all available commands, run `ocm support -h`.
 
+### Get
+
+The `get` command gets the given resource.
+
+#### Getting an account
+
+Use the `accounts` subcommand to get one or more accounts, passing as argument one of the following:
+
+* accountID
+* username
+* email
+* organizationID
+* organizationExternalID
+* organizationEBSAccountID
+
+Pass the search criteria as an optional second argument.
+
+The following flags are available for `get accounts`:
+
+```
+--first                      If true, returns only the first accounts that matched the search instead of all of them (default behaviour).
+--fetchRegistryCredentials   If true, includes the account registry credentials.
+--fetchRoles                 If true, includes the account roles.
+--fetchLabels                If true, includes the account labels.
+--fetchCapabilities          If true, includes the account capabilities.
+-h, --help                   help for get
+```
+
+##### Examples
+
+* Get the first account by email `ocm support get accounts user@redhat.com --first`
+* Get the account and include its roles in the results `ocm support get accounts [accountID] --fetchRoles`
+* Get the account and include its registry credentials `ocm support get accounts [username] --fetchRegistryCredentials`
+* Get all accounts for an organizationExternalID and include its labels in the results `ocm support get accounts [organizationExternalID] --fetchLabels`
+* Get all accounts for an organizationEBSAccountID and include its capabilities in the results `ocm support get accounts [organizationEBSAccountID] --fetchCapabilities`
+* Get all accounts from an organization `ocm support get accounts [organizationID]`
+
+#### Getting an organization
+
+Use the `organizations` subcommand to get one or more organizations, passing as argument one of the following:
+
+* organizationID
+* organizationExternalID
+* organizationEBSAccountID
+
+Pass the search criteria as an optional second argument.
+
+The following flags are available for `get organizations`:
+
+```
+--first                If true, returns only the first accounts that matched the search instead of all of them (default behaviour).
+--fetchQuota           If true, includes the organization quota.
+--fetchSubscriptions   If true, includes the organization subscriptions.
+--fetchLabels          If true, includes the organization labels.
+--fetchCapabilities    If true, includes the organization capabilities.
+--fetchSkus            If true, returns all the resource quota objects for the organization.
+-h, --help             help for get
+```
+
+##### Examples
+* Get the first organization by its externalID: `ocm support get organizations [organizationExternalID] --first`
+* Get the organization and include its subscriptions: `ocm support get organizations [organizationID] --fetchSubscriptions`
+* Get all organizations for an organizationExternalID and include its labels `ocm support get organizations [organizationExternalID] --fetchLabels`
+* Get all organizations for an organizationEBSAccountID and include its capabilities `ocm support get organizations [organizationEBSAccountID] --fetchCapabilities`
+* Get the first organization and include its quota: `ocm support get organizations [organizationID] --first --fetchQuota`
+* Get all organizations for an organizationExternalID and include its SKUs: `ocm support get organizations [organizationExternalID] --fetchSkus`
+
+#### Getting a subscription
+
+Use the `subscriptions` subcommand to get one or more subscriptions, passing as argument one of the following:
+
+* subscriptionID
+* clusterID
+* externalClusterID
+* organizationID
+
+Pass the search criteria as an optional second argument.
+
+The following flags are available for `get subscriptions`:
+
+```
+--first                If true, returns only the first subscription that matches the search instead of all of them (default behaviour).
+--fetchLabels          If true, includes the organization labels.
+--fetchCapabilities    If true, includes the organization capabilities.
+-h, --help             help for get
+```
+
+##### Examples
+
+* Get subscription by its ID: `ocm support get subscriptions [subscriptionID]`
+* Get all subscriptions by ClusterID and include its labels `ocm support get subscriptions [clusterID] --fetchLabels`
+* Get all subscriptions by ClusterID and include its capabilities `ocm support get subscriptions [clusterID] --fetchCapabilities`
+* Get first subscription by its externalClusterID: `ocm support get subscriptions [externalClusterID] --first`
+* Get all subscriptions by OrganizationID and include subscriptions that have Status as 'Reserverd' `ocm support get subscriptions [organizationID] "Status='Reserved'"`
+
+#### Getting registry credentials
+
+Use the `registryCredentials` subcommand to to get registry credentials, passing accountID.
+
+##### Examples
+
+* Show registry credentials for a specific account `ocm support get registryCredentials [accountID]`
+
 ### Create
 
 The `create` command creates the given resource.
@@ -204,102 +307,3 @@ Use the `subscriptionRoleBinding` subcommand to remove a role binding from an ac
 * For the given account, delete a role binding created at application level using the roleID `ocm support delete applicationRoleBinding [accountID] [roleID]`
 * For the given account, delete a role binding created at organization level using the roleID `ocm support delete organizationRoleBinding [accountID] [orgID] [roleID]`
 * For the given account, delete a role binding created at subscription level using the roleID `ocm support delete subscriptionRoleBinding [accountID] [subscriptionID] [roleID]`
-
-### Get
-
-The `get` command gets the given resource.
-
-#### Getting an account
-
-Use the `accounts` subcommand to get one or more accounts, passing as argument one of the following:
-
-* accountID
-* username
-* email
-* organizationID
-* organizationExternalID
-* organizationEBSAccountID
-
-The following flags are available for `get accounts`:
-
-```
---all                        If true, returns all accounts that matched the search instead of the first one only (default behaviour).
---fetchRegistryCredentials   If true, includes the account registry credentials.
---fetchRoles                 If true, includes the account roles.
---fetchLabels                If true, includes the account labels.
---fetchCapabilities          If true, includes the account capabilities.
--h, --help                   help for get
-```
-
-##### Examples
-
-* Get an account by email `ocm support get accounts user@redhat.com`
-* Get an account and include its roles in the results `ocm support get accounts [accountID] --fetchRoles`
-* Get an account and include its labels in the results `ocm support get accounts [accountID] --fetchLabels`
-* Get an account and include its capabilities in the results `ocm support get accounts [accountID] --fetchCapabilities`
-* Get all accounts from an organization `ocm support get accounts [organizationID] --all`
-
-#### Getting an organization
-
-Use the `organizations` subcommand to get one or more organizations, passing as argument one of the following:
-
-* organizationID
-* organizationExternalID
-* organizationEBSAccountID
-
-The following flags are available for `get organizations`:
-
-```
---all                  If true, returns all organizations that matched the search instead of the first one only (default behaviour).
---fetchQuota           If true, includes the organization quota.
---fetchSubscriptions   If true, includes the organization subscriptions.
---fetchLabels          If true, includes the organization labels.
---fetchCapabilities    If true, includes the organization capabilities.
---fetchSkus            If true, returns all the resource quota objects for the organization.
--h, --help             help for get
-```
-
-##### Examples
-
-* Get an organization by its externalID: `ocm support get organizations [organizationExternalID]`
-* Get an organization and include its subscriptions: `ocm support get organizations [organizationID] --fetchSubscriptions`
-* Get an organization and include its labels `ocm support get organizations [organizationID] --fetchLabels`
-* Get an organization and include its capabilities `ocm support get organizations [organizationID] --fetchCapabilities`
-* Get an organization and include its quota: `ocm support get organizations [organizationID] --fetchQuota`
-* Get an organization and include its SKUs: `ocm support get organizations [organizationID] --fetchSkus`
-
-#### Getting a subscription
-
-Use the `subscriptions` subcommand to get one or more subscriptions, passing as argument one of the following:
-
-* subscriptionID
-* clusterID
-* externalClusterID
-* organizationID
-
-Pass the search criteria as an optional second argument.
-
-The following flags are available for `get subscriptions`:
-
-```
---first                If true, returns only the first subscription that matches the search instead of all of them (default behaviour).
---fetchLabels          If true, includes the organization labels.
---fetchCapabilities    If true, includes the organization capabilities.
--h, --help             help for get
-```
-
-##### Examples
-
-* Get all subscriptions by its ID: `ocm support get subscriptions [subscriptionID]`
-* Get all subscriptions by ClusterID and include its labels `ocm support get subscriptions [clusterID] --fetchLabels`
-* Get all subscriptions by ClusterID and include its capabilities `ocm support get subscriptions [clusterID] --fetchCapabilities`
-* Get first subscription by its externalClusterID: `ocm support get subscriptions [externalClusterID] --first`
-* Get all subscriptions by OrganizationID and include subscriptions that have Status as 'Reserverd' `ocm support get subscriptions [organizationID] "Status='Reserved'"`
-
-#### Getting registry credentials
-
-Use the `registryCredentials` subcommand to to get registry credentials, passing accountID.
-
-##### Examples
-
-* Show registry credentials for a specific account `ocm support get registryCredentials [accountID]`

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The following flags are available for `organizations get`:
 --fetchSubscriptions   If true, includes the organization subscriptions.
 --fetchLabels          If true, includes the organization labels.
 --fetchCapabilities    If true, includes the organization capabilities.
+--fetchSkus            If true, returns all the resource quota objects for the organization.
 -h, --help             help for get
 ```
 
@@ -225,6 +226,7 @@ The following flags are available for `organizations get`:
 * Get an organization and include its labels `ocm support get organizations [organizationID] --fetchLabels --fetchCapabilities`
 * Get an organization and include its capabilities `ocm support get organizations [organizationID] --fetchCapabilities`
 * Get an organization and include its quota: `ocm support get organizations [organizationID] --fetchQuota`
+* Get an organization and include its resource quota: `ocm support get organizations [organizationID] --fetchQuota`
 
 #### Getting registry credentials
 

--- a/cmd/ocm-support/get/accounts/cmd.go
+++ b/cmd/ocm-support/get/accounts/cmd.go
@@ -88,7 +88,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
 
-	accounts, err := account.GetAccounts(key, size, args.fetchLabels, args.fetchCapabilities, searchStr, connection)
+	accounts, err := account.GetAccounts(key, searchStr, size, args.fetchLabels, args.fetchCapabilities, connection)
 	if err != nil {
 		_ = fmt.Errorf("failed to get accounts: %v", err)
 	}

--- a/cmd/ocm-support/get/organizations/cmd.go
+++ b/cmd/ocm-support/get/organizations/cmd.go
@@ -96,7 +96,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
 
-	organizations, err := organization.GetOrganizations(key, size, args.fetchLabels, args.fetchCapabilities, searchStr, connection)
+	organizations, err := organization.GetOrganizations(key, searchStr, size, args.fetchLabels, args.fetchCapabilities, connection)
 	if err != nil {
 		_ = fmt.Errorf("failed to get organizations: %v", err)
 	}

--- a/cmd/ocm-support/get/subscriptions/cmd.go
+++ b/cmd/ocm-support/get/subscriptions/cmd.go
@@ -70,7 +70,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("failed to create OCM connection: %v", err)
 	}
 
-	subscriptions, err := subscription.GetSubscriptions(key, size, args.fetchLabels, args.fetchCapabilities, searchStr, connection)
+	subscriptions, err := subscription.GetSubscriptions(key, searchStr, size, args.fetchLabels, args.fetchCapabilities, connection)
 	if err != nil {
 		return fmt.Errorf("failed to get subscriptions: %v", err)
 	}

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -28,13 +28,16 @@ type Account struct {
 	Capabilities        capability.CapabilityList                  `json:",omitempty"`
 }
 
-func GetAccounts(key string, limit int, fetchLabels bool, fetchCapabilities bool, conn *sdk.Connection) ([]*v1.Account, error) {
-	search := fmt.Sprintf("id = '%s'", key)
-	search += fmt.Sprintf("or username = '%s'", key)
-	search += fmt.Sprintf("or email = '%s'", key)
-	search += fmt.Sprintf("or organization.id = '%s'", key)
-	search += fmt.Sprintf("or organization.external_id = '%s'", key)
-	search += fmt.Sprintf("or organization.ebs_account_id = '%s'", key)
+func GetAccounts(key string, limit int, fetchLabels bool, fetchCapabilities bool, searchStr string, conn *sdk.Connection) ([]*v1.Account, error) {
+	search := fmt.Sprintf("(id = '%s'", key)
+	search += fmt.Sprintf(" or username = '%s'", key)
+	search += fmt.Sprintf(" or email = '%s'", key)
+	search += fmt.Sprintf(" or organization.id = '%s'", key)
+	search += fmt.Sprintf(" or organization.external_id = '%s'", key)
+	search += fmt.Sprintf(" or organization.ebs_account_id = '%s')", key)
+	if searchStr != "" {
+		search += fmt.Sprintf(" and %s", searchStr)
+	}
 
 	accounts, err := conn.AccountsMgmt().V1().Accounts().List().Parameter("fetchLabels", fetchLabels).Parameter("fetchCapabilities", fetchCapabilities).Size(limit).Search(search).Send()
 	if err != nil {

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -28,7 +28,7 @@ type Account struct {
 	Capabilities        capability.CapabilityList                  `json:",omitempty"`
 }
 
-func GetAccounts(key string, limit int, fetchLabels bool, fetchCapabilities bool, searchStr string, conn *sdk.Connection) ([]*v1.Account, error) {
+func GetAccounts(key string, searchStr string, limit int, fetchLabels bool, fetchCapabilities bool, conn *sdk.Connection) ([]*v1.Account, error) {
 	search := fmt.Sprintf("(id = '%s'", key)
 	search += fmt.Sprintf(" or username = '%s'", key)
 	search += fmt.Sprintf(" or email = '%s'", key)

--- a/pkg/organization/organization.go
+++ b/pkg/organization/organization.go
@@ -30,7 +30,7 @@ type Organization struct {
 	ResourceQuota []resourcequota.ResourceQuota `json:",omitempty"`
 }
 
-func GetOrganizations(key string, limit int, fetchLabels bool, fetchCapabilities bool, searchStr string, conn *sdk.Connection) ([]*v1.Organization, error) {
+func GetOrganizations(key string, searchStr string, limit int, fetchLabels bool, fetchCapabilities bool, conn *sdk.Connection) ([]*v1.Organization, error) {
 	search := fmt.Sprintf("(id = '%s'", key)
 	search += fmt.Sprintf(" or external_id = '%s'", key)
 	search += fmt.Sprintf(" or ebs_account_id = '%s')", key)

--- a/pkg/organization/organization.go
+++ b/pkg/organization/organization.go
@@ -30,10 +30,13 @@ type Organization struct {
 	ResourceQuota []resourcequota.ResourceQuota `json:",omitempty"`
 }
 
-func GetOrganizations(key string, limit int, fetchLabels bool, fetchCapabilities bool, conn *sdk.Connection) ([]*v1.Organization, error) {
-	search := fmt.Sprintf("id = '%s'", key)
-	search += fmt.Sprintf("or external_id = '%s'", key)
-	search += fmt.Sprintf("or ebs_account_id = '%s'", key)
+func GetOrganizations(key string, limit int, fetchLabels bool, fetchCapabilities bool, searchStr string, conn *sdk.Connection) ([]*v1.Organization, error) {
+	search := fmt.Sprintf("(id = '%s'", key)
+	search += fmt.Sprintf(" or external_id = '%s'", key)
+	search += fmt.Sprintf(" or ebs_account_id = '%s')", key)
+	if searchStr != "" {
+		search += fmt.Sprintf(" and %s", searchStr)
+	}
 
 	organizations, err := conn.AccountsMgmt().V1().Organizations().List().Parameter("fetchLabels", fetchLabels).Parameter("fetchCapabilities", fetchCapabilities).Size(limit).Search(search).Send()
 	if err != nil {

--- a/pkg/subscription/subscription.go
+++ b/pkg/subscription/subscription.go
@@ -116,7 +116,7 @@ func ValidateSubscription(subscriptionID string, conn *sdk.Connection) error {
 	return nil
 }
 
-func GetSubscriptions(key string, limit int, fetchLabels bool, fetchCapabilities bool, searchStr string, conn *sdk.Connection) ([]*v1.Subscription, error) {
+func GetSubscriptions(key string, searchStr string, limit int, fetchLabels bool, fetchCapabilities bool, conn *sdk.Connection) ([]*v1.Subscription, error) {
 	search := fmt.Sprintf("(id = '%s'", key)
 	search += fmt.Sprintf(" or cluster_id = '%s'", key)
 	search += fmt.Sprintf(" or external_cluster_id = '%s'", key)


### PR DESCRIPTION
**Changed**
- Added optional search argument in get accounts and organizations subcommands
- Passed search string to API calls
- Modified readme file
- Changed all flag to first

**Tested**
- Optional search should filter out the results when getting accounts and organizations
- First should return only first result, while all should return all the data