### PR TITLE
Separated out delete capability commands for deleting filter based and single capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,12 +294,27 @@ Use the `subscriptionCapability` subcommand to delete a capability from a subscr
 
 ##### Deleting type independent capabilities
 
-Use the `capability` subcommand to delete a capability by passing the ID, or provide filter value to search matching capabilities and delete them. By default the dry run flag will be enabled. Set `dryRun` flag to false to actually remove the resource.
+Use the `capabilities` subcommand to provide filter value to search matching capabilities and delete them. By default the dry run flag will be enabled. Set `dryRun` flag to false to actually remove the resource.
 
 The following flags are available for `delete capability`:
 
 ```
---filter                     If non-empty, filters and deletes the matching capabilities.
+--dryRun                     If false, it will execute the delete command call in instead of a dry run.
+--maxRecords                 Maximum number of affected records. Defaults to 100. Only effective when dryRun is set to false.
+-h, --help                   help for create
+```
+
+##### Examples
+
+* Delete all capabilities where key is 'capability.account.create_moa_clusters' (with no dry run) `ocm support delete capability --filter "key = 'capability.account.create_moa_clusters'" --dryRun=false --maxRecords-1000`
+
+##### Deleting type independent capability
+
+Use the `capability` subcommand to delete a capability by passing the ID. By default the dry run flag will be enabled. Set `dryRun` flag to false to actually remove the resource.
+
+The following flags are available for `delete capability`:
+
+```
 --dryRun                     If false, it will execute the delete command call in instead of a dry run.
 -h, --help                   help for create
 ```
@@ -307,7 +322,6 @@ The following flags are available for `delete capability`:
 ##### Examples
 
 * Delete a capability by its ID `ocm support delete capability [capabilityID]`
-* Delete all capabilities where key is 'capability.account.create_moa_clusters' (with no dry run) `ocm support delete capability --filter "key = 'capability.account.create_moa_clusters'" --dryRun=false`
 
 #### Deleting registry credentials
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ The following flags are available for `delete capability`:
 
 ##### Examples
 
-* Delete all capabilities where key is 'capability.account.create_moa_clusters' (with no dry run) `ocm support delete capability --filter "key = 'capability.account.create_moa_clusters'" --dryRun=false --maxRecords-1000`
+* Delete all capabilities where key is 'capability.account.create_moa_clusters' (with no dry run) `ocm support delete capabilities "key = 'capability.account.create_moa_clusters'" --dryRun=false --maxRecords=1000`
 
 ##### Deleting type independent capability
 

--- a/cmd/ocm-support/delete/capability/cmd.go
+++ b/cmd/ocm-support/delete/capability/cmd.go
@@ -44,6 +44,9 @@ func runDeleteCapability(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("expected exactly one argument")
 	}
 	id := argv[0]
+	if id == "" {
+		return fmt.Errorf("id cannot be empty")
+	}
 	capabilityToDelete, err := label.GetLabel(id, connection)
 	if err != nil {
 		return err

--- a/cmd/ocm-support/delete/capability/cmd.go
+++ b/cmd/ocm-support/delete/capability/cmd.go
@@ -1,0 +1,61 @@
+package capability
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-support-cli/cmd/ocm-support/utils"
+	"github.com/openshift-online/ocm-support-cli/pkg/label"
+	"github.com/openshift-online/ocm-support-cli/pkg/request"
+)
+
+var args struct {
+	dryRun bool
+}
+
+func init() {
+	flags := CmdDeleteCapability.Flags()
+	flags.BoolVar(
+		&args.dryRun,
+		"dryRun",
+		true,
+		"If false, it will execute the delete command call in instead of a dry run.",
+	)
+}
+
+// CmdDeleteCapability represents the delete capability command
+var CmdDeleteCapability = &cobra.Command{
+	Use:     "capability [capabilityID]",
+	Aliases: utils.Aliases["capability"],
+	Short:   "Removes a Capability for the given ID",
+	Long:    "Removes a Capability for the given ID",
+	RunE:    runDeleteCapability,
+	Args:    cobra.ExactArgs(1),
+}
+
+func runDeleteCapability(cmd *cobra.Command, argv []string) error {
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	if len(argv) != 1 {
+		return fmt.Errorf("expected exactly one argument")
+	}
+	id := argv[0]
+	capabilityToDelete, err := label.GetLabel(id, connection)
+	if err != nil {
+		return err
+	}
+	err = request.DeleteRequest(capabilityToDelete.HREF(), args.dryRun, connection)
+	if err != nil {
+		return fmt.Errorf("failed to delete capability %s: %v\n", capabilityToDelete.ID(), err)
+	}
+	if !args.dryRun {
+		fmt.Printf("capability %s deleted\n", capabilityToDelete.ID())
+	} else {
+		fmt.Printf("capability %s would have been deleted\n", capabilityToDelete.ID())
+	}
+	return nil
+}

--- a/cmd/ocm-support/delete/cmd.go
+++ b/cmd/ocm-support/delete/cmd.go
@@ -7,6 +7,7 @@ import (
 	accountCapability "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/capabilities/account_capability"
 	organizationCapability "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/capabilities/organization_capability"
 	subscriptionCapability "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/capabilities/subscription_capability"
+	"github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/capability"
 	accountLabel "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/labels/account_label"
 	organizationLabel "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/labels/organization_label"
 	subscriptionLabel "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/delete/labels/subscription_label"
@@ -35,5 +36,6 @@ func init() {
 	Cmd.AddCommand(applicationRoleBinding.CmdDeleteApplicationRoleBinding)
 	Cmd.AddCommand(organizationRoleBinding.CmdDeleteOrganizationRoleBinding)
 	Cmd.AddCommand(subscriptionRoleBinding.CmdDeleteSubscriptionRoleBinding)
-	Cmd.AddCommand(capabilities.CmdDeleteCapability)
+	Cmd.AddCommand(capabilities.CmdDeleteCapabilities)
+	Cmd.AddCommand(capability.CmdDeleteCapability)
 }

--- a/cmd/ocm-support/patch/accounts/cmd.go
+++ b/cmd/ocm-support/patch/accounts/cmd.go
@@ -26,7 +26,7 @@ var CmdPatchAccounts = &cobra.Command{
 	Short:   "Patches accounts matching the filter",
 	Long:    "Patches accounts matching the filter",
 	RunE:    run,
-	Args:    cobra.MaximumNArgs(1),
+	Args:    cobra.ExactArgs(1),
 }
 
 func init() {


### PR DESCRIPTION
**Changed**
- Separated command to delete single capability from filter based capabilities
- Modified readme

**Tested**
- delete capability should delete capability based on ID
- delete capabilities should delete filter matching capabilities