### PR TITLE
Add fetch-export-control flag to accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The following flags are available for `get accounts`:
 --fetch-roles                If true, includes the account roles.
 --fetch-labels               If true, includes the account labels.
 --fetch-capabilities         If true, includes the account capabilities.
+--fetch-export-control       If true, includes export control information.
 -h, --help                   help for get
 ```
 
@@ -81,6 +82,7 @@ The following flags are available for `get accounts`:
 * Get the first account by email `ocm support get accounts user@redhat.com --first`
 * Get the account and include its roles in the results `ocm support get accounts [accountID] --fetch-roles`
 * Get the account and include its registry credentials `ocm support get accounts [username] --fetch-registry-credentials`
+* Get the account and include export control information `ocm support get accounts [username] --fetch-export-control`
 * Get all accounts for an organizationExternalID and include its labels in the results `ocm support get accounts [organizationExternalID] --fetch-labels`
 * Get all accounts for an organizationEBSAccountID and include its capabilities in the results `ocm support get accounts [organizationEBSAccountID] --fetch-capabilities`
 * Get all accounts from an organization `ocm support get accounts [organizationID]`

--- a/pkg/account/account.go
+++ b/pkg/account/account.go
@@ -6,8 +6,10 @@ import (
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	v1 "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	v1Auth "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
 
 	"github.com/openshift-online/ocm-support-cli/pkg/capability"
+	exportcontrolreview "github.com/openshift-online/ocm-support-cli/pkg/export_control_review"
 	"github.com/openshift-online/ocm-support-cli/pkg/label"
 	"github.com/openshift-online/ocm-support-cli/pkg/organization"
 	"github.com/openshift-online/ocm-support-cli/pkg/registry_credential"
@@ -21,12 +23,16 @@ type Account struct {
 	LastName            string                                     `json:"last_name"`
 	Username            string                                     `json:"username"`
 	Email               string                                     `json:"email"`
+	Banned              bool                                       `json:"banned"`
+	BanCode             string                                     `json:"ban_code,omitempty"`
+	BanDescription      string                                     `json:"ban_description,omitempty"`
 	ServiceAccount      bool                                       `json:"service_account"`
 	Organization        organization.Organization                  `json:"organization,omitempty"`
 	Roles               []rolebinding.AccountRoleBinding           `json:"roles,omitempty"`
 	RegistryCredentials registry_credential.RegistryCredentialList `json:"registry_credentials,omitempty"`
 	Labels              label.LabelsList                           `json:"labels,omitempty"`
 	Capabilities        capability.CapabilityList                  `json:"capabilities,omitempty"`
+	ExportControl       *exportcontrolreview.ExportControlReview   `json:"export_control,omitempty"`
 }
 
 func GetAccounts(key string, searchStr string, limit int, fetchLabels bool, fetchCapabilities bool, searchOnly bool, conn *sdk.Connection) ([]*v1.Account, error) {
@@ -89,7 +95,7 @@ func DeleteLabel(accountID string, key string, conn *sdk.Connection) error {
 	return nil
 }
 
-func PresentAccount(account *v1.Account, roles []*v1.RoleBinding, registryCredentials []*v1.RegistryCredential) Account {
+func PresentAccount(account *v1.Account, roles []*v1.RoleBinding, registryCredentials []*v1.RegistryCredential, exportControlReview *v1Auth.ExportControlReviewResponse) Account {
 	return Account{
 		Meta: types.Meta{
 			ID:   account.ID(),
@@ -100,11 +106,15 @@ func PresentAccount(account *v1.Account, roles []*v1.RoleBinding, registryCreden
 		Username:            account.Username(),
 		Email:               account.Email(),
 		ServiceAccount:      account.ServiceAccount(),
+		Banned:              account.Banned(),
+		BanCode:             account.BanCode(),
+		BanDescription:      account.BanDescription(),
 		Organization:        organization.PresentOrganization(account.Organization(), []*v1.Subscription{}, []*v1.QuotaCost{}, []*v1.ResourceQuota{}),
 		Roles:               rolebinding.PresentAccountRoleBindings(roles),
 		RegistryCredentials: registry_credential.PresentRegistryCredentials(registryCredentials),
 		Labels:              label.PresentLabels(account.Labels()),
 		Capabilities:        capability.PresentCapabilities(account.Capabilities()),
+		ExportControl:       exportcontrolreview.PresentExportControlReview(exportControlReview),
 	}
 }
 

--- a/pkg/export_control_review/export_control_review.go
+++ b/pkg/export_control_review/export_control_review.go
@@ -1,0 +1,40 @@
+package account
+
+import (
+	"fmt"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1Auth "github.com/openshift-online/ocm-sdk-go/authorizations/v1"
+)
+
+type ExportControlReview struct {
+	Restricted bool `json:"restricted"`
+}
+
+func PostExportControlReview(username string, conn *sdk.Connection) (*v1Auth.ExportControlReviewResponse, error) {
+	exportControlReviewRequest, err := v1Auth.NewExportControlReviewRequest().AccountUsername(username).Build()
+	if err != nil {
+		return nil, fmt.Errorf("can't build export control request: %w", err)
+	}
+
+	exportResponse, err := conn.Authorizations().V1().ExportControlReview().Post().Request(exportControlReviewRequest).Send()
+	if err != nil {
+		return nil, fmt.Errorf("can't retrieve export control: %w", err)
+	}
+
+	responseBody := exportResponse.Response()
+
+	return responseBody, nil
+}
+
+func PresentExportControlReview(exportControlReview *v1Auth.ExportControlReviewResponse) *ExportControlReview {
+	var export *ExportControlReview = nil
+
+	if exportControlReview != nil {
+		export = &ExportControlReview{
+			Restricted: exportControlReview.Restricted(),
+		}
+	}
+
+	return export
+}


### PR DESCRIPTION
This is to enable the fetching of export control information for accounts. This will streamline the process of investigating support tickets that require manual export control review.