### PR TITLE
Fetch ROSA Classic attributes

### DIFF
--- a/cmd/ocm-support/get/clusters/cmd.go
+++ b/cmd/ocm-support/get/clusters/cmd.go
@@ -1,0 +1,113 @@
+package clusters
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+
+	"github.com/openshift-online/ocm-cli/pkg/ocm"
+	"github.com/openshift-online/ocm-support-cli/cmd/ocm-support/utils"
+	"github.com/openshift-online/ocm-support-cli/pkg/cluster_info"
+	"github.com/spf13/cobra"
+)
+
+var args struct {
+	outputCSV     bool
+	outputCSVFile string
+}
+
+var CmdGetClusters = &cobra.Command{
+	Use:     "clusters [organization_id]",
+	Aliases: utils.Aliases["clusters"],
+	Short:   "Gets a list of cluster information for a given organization",
+	Long:    "Fetches a list of cluster information for a given organization and generates a JSON or CSV file with the relevant details.",
+	RunE:    run,
+	Args:    cobra.ExactArgs(1),
+}
+
+func init() {
+	flags := CmdGetClusters.Flags()
+	flags.BoolVar(
+		&args.outputCSV,
+		"csv",
+		false,
+		"Outputs the data in CSV format instead of JSON.",
+	)
+	flags.StringVar(
+		&args.outputCSVFile,
+		"csv-file",
+		"clusters.csv",
+		"Specify the name of the output CSV file (used only if --csv is set).",
+	)
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	// Get the org-id from the arguments
+	orgID := argv[0]
+
+	// Establish an OCM connection
+	connection, err := ocm.NewConnection().Build()
+	if err != nil {
+		return fmt.Errorf("failed to create OCM connection: %v", err)
+	}
+	defer connection.Close()
+
+	// Call the clusterinfo package to fetch data and generate the CSV
+	clusters, err := cluster_info.FetchClusters(orgID, connection)
+	if err != nil {
+		return fmt.Errorf("failed to generate cluster information: %v", err)
+	}
+
+	if len(clusters) == 0 {
+		return fmt.Errorf("no clusters found")
+	}
+
+	if args.outputCSV {
+		// Outputs CSV
+		err = outputCSV(clusters)
+		if err != nil {
+			return fmt.Errorf("failed to output data in CSV format: %w", err)
+		}
+	} else {
+		// Output JSON
+		utils.PrettyPrint(clusters)
+	}
+
+	return nil
+}
+
+func outputCSV(clusters []cluster_info.ClusterInfo) error {
+	file, err := os.Create(args.outputCSVFile)
+	if err != nil {
+		return fmt.Errorf("failed to create file '%s': %w", args.outputCSVFile, err)
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	// Write CSV headers
+	headers := []string{"Cluster UUID", "Cluster Name", "Display Name", "Machine Pool Name", "Node Instance Type", "Node Quantity", "Max Machine Pool Scale"}
+	if err := writer.Write(headers); err != nil {
+		return fmt.Errorf("can't write CSV headers: %v", err)
+	}
+
+	// Write rows
+	for _, cluster := range clusters {
+		row := []string{
+			cluster.UUID,
+			cluster.Name,
+			cluster.DisplayName,
+			cluster.MachinePoolName,
+			cluster.NodeInstanceType,
+			cluster.NodeQuantity,
+			cluster.MaxMachinePoolScale,
+		}
+		if err := writer.Write(row); err != nil {
+			return fmt.Errorf("can't write CSV row: %v", err)
+		}
+	}
+
+	fmt.Printf("CSV file '%s' has been successfully created.\n", args.outputCSVFile)
+	return nil
+}

--- a/cmd/ocm-support/get/cmd.go
+++ b/cmd/ocm-support/get/cmd.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"github.com/openshift-online/ocm-support-cli/cmd/ocm-support/get/accounts"
+	"github.com/openshift-online/ocm-support-cli/cmd/ocm-support/get/clusters"
 	"github.com/openshift-online/ocm-support-cli/cmd/ocm-support/get/organizations"
 	registrycredentials "github.com/openshift-online/ocm-support-cli/cmd/ocm-support/get/registry_credentials"
 	"github.com/openshift-online/ocm-support-cli/cmd/ocm-support/get/subscriptions"
@@ -21,4 +22,5 @@ func init() {
 	Cmd.AddCommand(organizations.CmdGetOrganizations)
 	Cmd.AddCommand(registrycredentials.CmdGetRegistryCredentials)
 	Cmd.AddCommand(subscriptions.CmdGetSubscriptions)
+	Cmd.AddCommand(clusters.CmdGetClusters)
 }

--- a/pkg/cluster_info/cluster_info.go
+++ b/pkg/cluster_info/cluster_info.go
@@ -1,0 +1,100 @@
+package cluster_info
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+type ClusterInfo struct {
+	UUID                string `json:"uuid"`
+	Name                string `json:"name"`
+	DisplayName         string `json:"display_name"`
+	MachinePoolName     string `json:"machine_pool_name"`
+	NodeInstanceType    string `json:"node_instance_type"`
+	NodeQuantity        string `json:"node_quantity"`
+	MaxMachinePoolScale string `json:"max_machine_pool_scale"`
+}
+
+// fetches cluster and machine pool details and exports them to a CSV file
+func FetchClusters(orgID string, connection *sdk.Connection) ([]ClusterInfo, error) {
+	var clustersInfo []ClusterInfo
+	var iterationError error
+
+	ctx := context.Background()
+
+	// Access the clusters collection API
+	collection := connection.ClustersMgmt().V1().Clusters()
+
+	// Search string for org.id, rosa, and HCP is false
+	searchQuery := fmt.Sprintf("organization.id='%s' and product.id='rosa' and hypershift.enabled='false'", orgID)
+
+	// Fetch clusters in pages to handle large datasets
+	size := 10
+	page := 1
+	for {
+		response, err := collection.List().
+			Search(searchQuery).
+			Size(size).
+			Page(page).
+			SendContext(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve clusters: %w", err)
+		}
+
+		// Process clusters and machine pools
+		response.Items().Each(func(cluster *cmv1.Cluster) bool {
+			// Fetch the list of all machine pools associated with the given cluster
+			machinePoolsResponse, err := collection.Cluster(cluster.ID()).MachinePools().List().SendContext(ctx)
+			if err != nil {
+				iterationError = fmt.Errorf("failed to retrieve machine pools for cluster %s: %w", cluster.ID(), err)
+				return false
+			}
+
+			machinePoolsResponse.Items().Each(func(pool *cmv1.MachinePool) bool {
+				// Determine node quantity
+				nodeQuantity := "0"
+				if pool.Autoscaling() != nil && pool.Autoscaling().MaxReplicas() > 0 {
+					// if autoscaling is enabled
+					nodeQuantity = "dynamic-scaling"
+				} else {
+					nodeQuantity = strconv.Itoa(pool.Replicas())
+				}
+
+				// Determine max replicas
+				maxReplicas := "disabled"
+				if pool.Autoscaling() != nil {
+					// Set maxReplicas if autoscaling is enabled
+					maxReplicas = strconv.Itoa(pool.Autoscaling().MaxReplicas())
+				}
+
+				clustersInfo = append(clustersInfo, ClusterInfo{
+					UUID:                cluster.ID(),
+					Name:                cluster.Name(),
+					DisplayName:         cluster.Name(), // Display name is the same as name
+					MachinePoolName:     pool.ID(),
+					NodeInstanceType:    pool.InstanceType(),
+					NodeQuantity:        nodeQuantity,
+					MaxMachinePoolScale: maxReplicas,
+				})
+
+				return true
+			})
+			return true
+		})
+
+		if iterationError != nil {
+			return nil, iterationError
+		}
+
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	return clustersInfo, nil
+}


### PR DESCRIPTION
### Description
This feature introduces a new command to retrieve ROSA Classic Cluster attributes based on `organization_id`. 

### Key Features
- Defaults Output: JSON format.
- CSV Support: Use the `--csv` flag to output to a CSV file (`clusters.csv` by default)
- Custom CSV File Name: Add the `--csv-file` flag to specify a custom file name.

### Usage Examples:

Input:
`ocm-support get clusters [org_id]`

Result:
```
[
  {
    "uuid": "1 ..... a",
    "name": "cluster-name1",
    "display_name": "cluster-name1",
    "machine_pool_name": "mp-name",
    "node_instance_type": "m2.xlarge",
    "node_quantity": "1",
    "max_machine_pool_scale": "disabled"
  },
...
]
```

Input:
`ocm-support get clusters [org_id] --csv`

Result:
```
CSV file 'clusters.csv' has been successfully created.
```

Input:
`ocm-support get clusters [org_id] --csv --csv-file "my_cluster_info.csv"`

Result:
```
CSV file 'my_cluster_info.csv' has been successfully created.
```