### PR TITLE
added fetch machine pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ Pass the search criteria as an optional second argument.
 The following flags are available for `get clusters`:
 
 ```
---first If true, returns only the first cluster that matches the search instead of all of them (default behaviour). -h, --help help for get
+--first                   If true, returns only the first cluster that matches the search instead of all of them (default behaviour).
+--fetch-machinepools      If true, includes the machine pools.
+
 ```
 
 ##### Examples
@@ -173,7 +175,7 @@ The following flags are available for `get clusters`:
 * Get all clusters by OrganizationID and include search criteria: `ocm support get clusters [organizationID] "state='ready'"`
 * Get first cluster by its externalClusterID: `ocm support get clusters [externalClusterID] --first`
 * Get first cluster by SubscriptionID: `ocm support get clusters [subscriptionID] --first`
-
+* Get cluster by its ID and include its machine pools: `ocm support get clusters [clusterID] --fetch-machinepools`
 
 #### Getting registry credentials
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -6,28 +6,30 @@ import (
 	"time"
 
 	sdk "github.com/openshift-online/ocm-sdk-go"
-	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	machinepool "github.com/openshift-online/ocm-support-cli/pkg/machine_pool"
 )
 
 type Cluster struct {
-	ID                string    `json:"id"`
-	HREF              string    `json:"href"`
-	Name              string    `json:"name"`
-	ExternalID        string    `json:"external_id"`
-	DisplayName       string    `json:"display_name"`
-	SubscriptionID    string    `json:"subscription_id"`
-	State             string    `json:"state"`
-	CloudProvider     string    `json:"cloud_provider"`
-	Version           string    `json:"version"`
-	RegionID          string    `json:"region_id"`
-	MultiAZ           bool      `json:"multi_az"`
-	ProductID         string    `json:"product_id"`
-	Managed           bool      `json:"managed"`
-	ConsoleURL        string    `json:"console_url"`
-	CreationTimestamp time.Time `json:"creation_timestamp"`
+	ID                string                    `json:"id"`
+	HREF              string                    `json:"href"`
+	Name              string                    `json:"name"`
+	ExternalID        string                    `json:"external_id"`
+	DisplayName       string                    `json:"display_name"`
+	SubscriptionID    string                    `json:"subscription_id"`
+	State             string                    `json:"state"`
+	CloudProvider     string                    `json:"cloud_provider"`
+	Version           string                    `json:"version"`
+	RegionID          string                    `json:"region_id"`
+	MultiAZ           bool                      `json:"multi_az"`
+	MachinePools      []machinepool.MachinePool `json:"machine_pools,omitempty"`
+	ProductID         string                    `json:"product_id"`
+	Managed           bool                      `json:"managed"`
+	ConsoleURL        string                    `json:"console_url"`
+	CreationTimestamp time.Time                 `json:"creation_timestamp"`
 }
 
-func GetClusters(key string, searchStr string, limit int, connection *sdk.Connection) ([]*cmv1.Cluster, error) {
+func GetClusters(key string, searchStr string, limit int, fetchMachinePools bool, connection *sdk.Connection) ([]*v1.Cluster, error) {
 	// Validate key
 	if key == "" {
 		return nil, fmt.Errorf("organization ID cannot be empty")
@@ -35,8 +37,8 @@ func GetClusters(key string, searchStr string, limit int, connection *sdk.Connec
 
 	var search string
 
-	search = fmt.Sprintf("(id = '%s'", key) // cluster_id
-	search += fmt.Sprintf(" or external_id = '%s'", key)
+	search = fmt.Sprintf("(id = '%s'", key)              // cluster_id
+	search += fmt.Sprintf(" or external_id = '%s'", key) //external_cluster_id
 	search += fmt.Sprintf(" or organization.id = '%s'", key)
 	search += fmt.Sprintf(" or subscription.id = '%s')", key)
 	if searchStr != "" {
@@ -48,13 +50,13 @@ func GetClusters(key string, searchStr string, limit int, connection *sdk.Connec
 		Search(search).
 		SendContext(context.Background())
 	if err != nil {
-		return []*cmv1.Cluster{}, fmt.Errorf("failed to retrieve clusters: %w", err)
+		return []*v1.Cluster{}, fmt.Errorf("failed to retrieve clusters: %w", err)
 	}
 
 	return clusters.Items().Slice(), nil
 }
 
-func PresentClusters(cluster *cmv1.Cluster) Cluster {
+func PresentClusters(cluster *v1.Cluster, mp []*v1.MachinePool) Cluster {
 	return Cluster{
 		ID:                cluster.ID(),
 		HREF:              cluster.HREF(),
@@ -67,6 +69,7 @@ func PresentClusters(cluster *cmv1.Cluster) Cluster {
 		Version:           cluster.OpenshiftVersion(),
 		RegionID:          cluster.Region().ID(),
 		MultiAZ:           cluster.MultiAZ(),
+		MachinePools:      machinepool.PresentMachinePool(mp),
 		ProductID:         cluster.Product().ID(),
 		Managed:           cluster.Managed(),
 		ConsoleURL:        cluster.Console().URL(),

--- a/pkg/machine_pool/machine_pool.go
+++ b/pkg/machine_pool/machine_pool.go
@@ -1,0 +1,63 @@
+package machinepool
+
+import (
+	"context"
+	"fmt"
+
+	sdk "github.com/openshift-online/ocm-sdk-go"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+type MachinePool struct {
+	ID           string            `json:"id"`
+	InstanceType string            `json:"instance_type"`
+	Replicas     int               `json:"replicas"`
+	Autoscaling  bool              `json:"autoscaling"`
+	MaxReplicas  int               `json:"max_replicas,omitempty"`
+	MinReplicas  int               `json:"min_replicas,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+}
+
+func GetMachinePool(clusterID string, connection *sdk.Connection) ([]*v1.MachinePool, error) {
+	if clusterID == "" {
+		return nil, fmt.Errorf("clusterID cannot be empty")
+	}
+
+	machine_pool, err := connection.ClustersMgmt().V1().Clusters().
+		Cluster(clusterID).
+		MachinePools().
+		List().
+		SendContext(context.Background())
+
+	if err != nil {
+		return []*v1.MachinePool{}, fmt.Errorf("failed to retrieve machinepool: %w", err)
+	}
+
+	return machine_pool.Items().Slice(), nil
+}
+
+func PresentMachinePool(pools []*v1.MachinePool) []MachinePool {
+	var machinePools []MachinePool
+
+	for _, pool := range pools {
+		mp := MachinePool{
+			ID:           pool.ID(),
+			InstanceType: pool.InstanceType(),
+			Replicas:     pool.Replicas(),
+			Autoscaling:  pool.Autoscaling() != nil,
+		}
+
+		if pool.Autoscaling() != nil {
+			mp.MaxReplicas = pool.Autoscaling().MaxReplicas()
+			mp.MinReplicas = pool.Autoscaling().MinReplicas()
+		}
+
+		if pool.Labels() != nil {
+			mp.Labels = pool.Labels()
+		}
+
+		machinePools = append(machinePools, mp)
+	}
+
+	return machinePools
+}


### PR DESCRIPTION
### Description
This feature introduces a new parameter for get Clusters to retrieve and add a list of machine pools for a cluster or list of clusters. 

### Key Features
- Adds `--fetch-machinepools` to include machinepool information about the cluster(s).

### Usage Examples:

Input:
`ocm-support get clusters [org_id] --fetch-machinepools`

Result:
```
[
  {
    "id": "1 ... a",
    "href": "/api/clusters_mgmt/v1/clusters/[cluster_id]",
    "name": "cluster-name1",
    "external_id": "1 ... c"
    "display_name": "cluster-name1",
    "subscription_id": "1 ... b",
    "state": "ready",
    "cloud_provider": "aws",
    "version": "4.16.0",
    "region_id": "us-east-1",
    "multi_az": true,
    "machine_pools": [
      {
        "id": "worker-1",
        "instance_type": "m5.2xlarge",
        "replicas": 0,
        "autoscaling": true,
        "max_replicas": 20,
        "min_replicas": 3
      },
      {
        "id": "worker-2",
        "instance_type": "m5.xlarge",
        "replicas": 3,
        "autoscaling": false
      }
    ]
    "product_id": "rosa",
    "managed": true,
    "console_url": "https://console-openshift-console.apps.cluster-name1.com",
    "creation_timestamp": "2024-07-01T01:00:00.000000Z",
  },
...
]
```
